### PR TITLE
Pass options into start_link; support QCSTROREQ

### DIFF
--- a/src/medici.erl
+++ b/src/medici.erl
@@ -57,13 +57,17 @@ start() ->
 %% options until you restart your Erlang VM.
 %% @end
 start(StartupOptions) when is_list(StartupOptions) ->
-    {ok, AppEnvOptions} = application:get_env(medici, options),
-    CombinedOptions = [StartupOptions | AppEnvOptions],
+    AppEnvOptions = case application:get_env(medici, options) of
+        {ok, Val} -> Val;
+        undefined -> []
+    end,
+    CombinedOptions = StartupOptions ++ AppEnvOptions,
     %% Merge into a single set of options, favoring those passed in
     %% to start/1 over the app env.
     MediciOptions = [{K, proplists:get_value(K, CombinedOptions)} || 
-			K <- proplists:get_keys(CombinedOptions)],
-    application:put_env(medici, {options, MediciOptions}),
+        K <- proplists:get_keys(CombinedOptions)],
+    application:load(medici),
+    ok = application:set_env(medici, options, MediciOptions),
     application:start(medici).
 
 stop() ->

--- a/src/medici_conn.erl
+++ b/src/medici_conn.erl
@@ -24,7 +24,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -37,8 +37,10 @@
 %% @spec start_link() -> {ok,Pid} | ignore | {error,Error}
 %% @private Starts the connection handler
 start_link() ->
-    {ok, MediciOpts} = application:get_env(medici, options),
-    gen_server:start_link(?MODULE, MediciOpts, []).
+    start_link([]).
+
+start_link(StartArgs) ->
+    gen_server:start_link(?MODULE, StartArgs, []).
 
 %%====================================================================
 %% gen_server callbacks

--- a/src/medici_conn_sup.erl
+++ b/src/medici_conn_sup.erl
@@ -42,20 +42,19 @@ start_link(StartArgs) ->
 %% to find out about restart strategy, maximum restart frequency and child 
 %% specifications.
 %%--------------------------------------------------------------------
-init(StartArgs) ->
-    {ok, MediciOpts} = application:get_env(options),
+init(MediciOpts) ->
     ClientCount = proplists:get_value(num_connections, MediciOpts, ?NUM_CLIENTS),
     case proplists:get_bool(native, MediciOpts) of
 	false ->
 	    ChildList = [{list_to_atom("medici_connection_"++integer_to_list(ChildNum)), 
-			  {medici_conn, start_link, StartArgs},
+			  {medici_conn, start_link, [MediciOpts]},
 			  permanent,
 			  2000,
 			  worker,
 			  [medici_conn]} || ChildNum <- lists:seq(1, ClientCount)];
 	true ->
 	    ChildList = [{list_to_atom("medici_connection_"++integer_to_list(ChildNum)), 
-			  {medici_native_conn, start_link, StartArgs},
+			  {medici_native_conn, start_link, [MediciOpts]},
 			  permanent,
 			  2000,
 			  worker,

--- a/src/medici_controller.erl
+++ b/src/medici_controller.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -28,7 +28,9 @@
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 start_link() ->
-    {ok, MediciOpts} = application:get_env(options),
+    start_link([]).
+
+start_link(MediciOpts) ->
     MyName = proplists:get_value(controller_name, MediciOpts, ?CONTROLLER_NAME),
     gen_server:start_link({local, MyName}, ?MODULE, MediciOpts, []).
 

--- a/src/medici_native_conn.erl
+++ b/src/medici_native_conn.erl
@@ -26,7 +26,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -39,7 +39,9 @@
 %% @spec start_link() -> {ok,Pid} | ignore | {error,Error}
 %% @private Starts the connection handler
 start_link() ->
-    {ok, MediciOpts} = application:get_env(options),
+    start_link([]).
+
+start_link(MediciOpts) ->
     gen_server:start_link(?MODULE, MediciOpts, []).
 
 %%====================================================================

--- a/src/medici_native_controller.erl
+++ b/src/medici_native_controller.erl
@@ -10,7 +10,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -28,7 +28,9 @@
 %% Description: Starts the server
 %%--------------------------------------------------------------------
 start_link() ->
-    {ok, MediciOpts} = application:get_env(options),
+    start_link([]).
+
+start_link(MediciOpts) ->
     MyName = proplists:get_value(controller, MediciOpts, ?CONTROLLER_NAME),
     gen_server:start_link({local, MyName}, ?MODULE, MediciOpts, []).
 

--- a/src/medici_port_srv.erl
+++ b/src/medici_port_srv.erl
@@ -22,7 +22,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, start_link/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -43,12 +43,10 @@
 %%
 %% @private Start the Tyrant port server
 start_link() ->
-    case application:get_env(options) of
-	{ok, MediciOpts} ->
-	    ServerOpts = proplists:get_value(run_server, MediciOpts, []);
-	_ ->
-	    ServerOpts = []
-    end,
+    start_link([]).
+
+start_link(MediciOpts) ->
+    ServerOpts = proplists:get_value(run_server, MediciOpts, []),
     case proplists:get_value(server_name, ServerOpts) of
 	undefined ->
 	    gen_server:start_link({local, ?PORT_SRV_NAME}, ?MODULE, [], []);
@@ -59,15 +57,10 @@ start_link() ->
 %%====================================================================
 %% gen_server callbacks
 %%====================================================================
-init(_Args) ->
+init(MediciOpts) ->
     {ok, LogMatch} = re:compile(?LOG_REGEXP),
     {ok, PidMatch} = re:compile(?PID_REGEXP),
-    case application:get_env(options) of
-	{ok, MediciOpts} ->
-	    ServerOpts = proplists:get_value(run_server, MediciOpts, []);
-	_ ->
-	    ServerOpts = []
-    end,
+    ServerOpts = proplists:get_value(run_server, MediciOpts, []),
     process_flag(trap_exit, true),
     start_server(ServerOpts, #state{log_match=LogMatch,
 				    pid_match=PidMatch}).


### PR DESCRIPTION
These are changes I've been running in Chicago Boss for some time now. Some are obvious bug-fixes (such as the call to put_env), and others are API changes which you may not approve of. Let me know what you think. Here are the commit notes:

Use a more traditional approach to passing in options (directly instead
of only via get_env). Replace put_env (which doesn't exist) with
set_env. Fix various warnings. Support QCSTROREQ operator. Make all
principe_table functions take the socket as a first argument for
consistency.
